### PR TITLE
bumped agentkit versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ langchain-fireworks = "^0.2.6"
 langchain-openai = "^0.3.6"
 langgraph = "^0.2.74"
 pydantic = ">=2.7.1,<=2.10.6"
-coinbase-agentkit = "^0.1.2"
-coinbase-agentkit-langchain = "^0.1.0"
+coinbase-agentkit = ">= 0.4.0"
+coinbase-agentkit-langchain = ">= 0.3.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.11.0"


### PR DESCRIPTION
This PR will increment the versions of
```
coinbase-agentkit >= 0.4.0
coinbase-agentkit-langchain >= 0.3.0
```

and solves version conflict for this PR:
https://github.com/nearai/nearai/pull/1098

related to
https://github.com/nearai/nearai/issues/1097